### PR TITLE
adding license entry to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     author='confirm IT solutions',
     author_email='pypi@confirm.ch',
     url='https://github.com/confirm/ansibleci',
+    license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
adding the license entry to setup.py, so that it appear on the pypi page.
