### PR TITLE
DOCS: Added TEST commit message prefix

### DIFF
--- a/docs/contribution.rst
+++ b/docs/contribution.rst
@@ -83,6 +83,7 @@ Also make sure you use **proper commit messages** and **prefix** them with:
 * ``DOCS: Updated the documentation for foobar``
 * ``REFACTOR: Refactored code of foobar`` *which didn't affect the meaning of the code itself*
 * ``STYLE: Updated code style of foobar``
+* ``TEST: Added new Travis CI test for foobar``
 
 If there's an issue available (especially for bugs) make sure you mention the **issue number** it in the git commit message as well:
 


### PR DESCRIPTION
We need to keep the "test shizzle" away from the changelog. The end user doesn't really care about that stuff.
